### PR TITLE
ZCS-12704: adding a sample extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+This is a sample extension to handle a notification called by `notifyExtension`, which is introduced in ZCS-12704 https://github.com/Zimbra/zm-mailbox/pull/1431

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,12 @@
+<project name="sample-extension" default="jar">
+  <import file="../zm-zcs/ant-global.xml" />
+  <property name="jar.file" value="sample-extension.jar"/>
+
+  <target name="jar" depends="compile" description="Creates extension jar file">
+    <antcall target="zimbra-jar">
+      <param name="jar.file" value="${jar.file}" />
+      <param name="implementation.title" value="Sample Extension" />
+      <param name="zimbra.extension.class" value="com.zimbra.cs.example.SampleExtension" />
+    </antcall>
+  </target>
+</project>

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<ivy-module version="2.0"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd">
+ <info organisation="zimbra" module="sample-extension" status="release">
+ </info>
+
+ <dependencies>
+  <dependency org="zimbra" name="zm-common" rev="latest.integration" />
+  <dependency org="zimbra" name="zm-soap" rev="latest.integration" />
+  <dependency org="zimbra" name="zm-client" rev="latest.integration" />
+  <dependency org="zimbra" name="zm-store" rev="latest.integration" />
+  <!-- Other than zimbra dependencies  -->
+  <dependency org="org.dom4j" name="dom4j" rev="${dom4j.version}" />
+ </dependencies>
+</ivy-module>

--- a/src/java/com/zimbra/cs/example/SampleExtension.java
+++ b/src/java/com/zimbra/cs/example/SampleExtension.java
@@ -1,0 +1,57 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.example;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.cs.extension.ZimbraExtension;
+import com.zimbra.cs.extension.ZimbraExtensionNotification;
+
+public class SampleExtension implements ZimbraExtension {
+
+    /**
+     * Defines a name for the extension. It must be an identifier.
+     *
+     * @return extension name
+     */
+    @Override
+    public String getName() {
+        return "sampleExtension";
+    }
+
+    /**
+     * Initializes the extension. Called when the extension is loaded.
+     *
+     * @throws com.zimbra.common.service.ServiceException
+     */
+    public void init() throws ServiceException {
+        /*
+         * specify a notification ID in the first argument
+         */
+        ZimbraExtensionNotification.register("com.zimbra.cs.service.account.Auth:validate", new SampleNotificationHandler());
+        ZimbraExtensionNotification.register("com.zimbra.cs.service.admin.Auth:validate", new SampleNotificationHandler2());
+    }
+
+    /**
+     * Terminates the extension. Called when the server is shut down.
+     */
+    @Override
+    public void destroy() {
+        SampleNotificationHandler.unregister("com.zimbra.cs.service.account.Auth:validate");
+        SampleNotificationHandler.unregister("com.zimbra.cs.service.admin.Auth:validate");
+    }
+}

--- a/src/java/com/zimbra/cs/example/SampleNotificationHandler.java
+++ b/src/java/com/zimbra/cs/example/SampleNotificationHandler.java
@@ -1,0 +1,82 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.example;
+
+import java.util.Map;
+
+import com.zimbra.common.account.Key;
+import com.zimbra.common.account.Key.AccountBy;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Domain;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.extension.ZimbraExtensionNotification;
+
+public class SampleNotificationHandler extends ZimbraExtensionNotification {
+    @Override
+    public void execute(Object[] args) throws ServiceException {
+        /*
+         * It is responsible for an extension to cast a parameter to a right class
+         */
+        Element request = (Element) args[0];
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> context = (Map<String, Object>) args[1];
+
+
+        /*
+         * The first part is based on com.zimbra.cs.service.account.Auth#handle(Element request, Map<String, Object> context)
+         */
+        Provisioning prov = Provisioning.getInstance();
+        String acctValuePassedIn = null, acctValue = null, acctByStr = null;
+        AccountBy acctBy = null;
+        Account acct = null;
+        Element acctEl = request.getOptionalElement(AccountConstants.E_ACCOUNT);
+        if (acctEl != null) {
+            acctValuePassedIn = acctEl.getText();
+            acctValue = acctValuePassedIn;
+            acctByStr = acctEl.getAttribute(AccountConstants.A_BY, AccountBy.name.name());
+            acctBy = AccountBy.fromString(acctByStr);
+            if (acctBy == AccountBy.name) {
+                Element virtualHostEl = request.getOptionalElement(AccountConstants.E_VIRTUAL_HOST);
+                String virtualHost = virtualHostEl == null ? null : virtualHostEl.getText().toLowerCase();
+                if (virtualHost != null && acctValue.indexOf('@') == -1) {
+                    Domain d = prov.get(Key.DomainBy.virtualHostname, virtualHost);
+                    if (d != null)
+                        acctValue = acctValue + "@" + d.getName();
+                }
+            }
+            acct = prov.get(acctBy, acctValue);
+        }
+
+        /*
+         * Add custom validation.
+         * In this example, if email address contains "invalid", the access is denied.
+         */
+        if (acct != null) {
+            String accountName = acct.getName();
+            ZimbraLog.extensions.info("SampleExt: name=" + accountName);
+            if (accountName.contains("invalid")) {
+                throw ServiceException.PERM_DENIED("Access Denied. name=" + accountName);
+            }
+        }
+    }
+}

--- a/src/java/com/zimbra/cs/example/SampleNotificationHandler2.java
+++ b/src/java/com/zimbra/cs/example/SampleNotificationHandler2.java
@@ -1,0 +1,81 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2022 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.cs.example;
+
+import java.util.Map;
+
+import com.zimbra.common.account.Key.AccountBy;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.AdminConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.Account;
+import com.zimbra.cs.account.Provisioning;
+import com.zimbra.cs.extension.ZimbraExtensionNotification;
+import com.zimbra.cs.util.AccountUtil;
+import com.zimbra.soap.DocumentHandler;
+import com.zimbra.soap.ZimbraSoapContext;
+
+public class SampleNotificationHandler2 extends ZimbraExtensionNotification {
+    @Override
+    public void execute(Object[] args) throws ServiceException {
+        /*
+         * It is responsible for an extension to cast a parameter to a right class
+         */
+        Element request = (Element) args[0];
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> context = (Map<String, Object>) args[1];
+
+
+        /*
+         * The first part is based on com.zimbra.cs.service.admin.Auth#handle(Element request, Map<String, Object> context)
+         */
+        ZimbraSoapContext zsc = DocumentHandler.getZimbraSoapContext(context);
+        Provisioning prov = Provisioning.getInstance();
+        String name = request.getAttribute(AdminConstants.E_NAME, null);
+        Element acctEl = request.getOptionalElement(AccountConstants.E_ACCOUNT);
+        AccountBy by;
+        String acctName = null;
+        Element virtualHostEl = request.getOptionalElement(AccountConstants.E_VIRTUAL_HOST);
+        String virtualHost = virtualHostEl == null ? null : virtualHostEl.getText().toLowerCase();
+        if (name != null) {
+            acctName = name;
+            by = AccountBy.name;
+        } else {
+            acctName = acctEl.getText();
+            String byStr = acctEl.getAttribute(AccountConstants.A_BY, AccountBy.name.name());
+            by = AccountBy.fromString(byStr);
+        }
+        Account acct = AccountUtil.getAccount(by, acctName, virtualHost, zsc.getAuthToken(), prov);
+
+
+        /*
+         * Add custom validation.
+         * In this example, if email address contains "invalid", the access is denied.
+         */
+        if (acct != null) {
+            String accountName = acct.getName();
+            ZimbraLog.extensions.info("SampleExt: name=" + accountName);
+            if (!"zimbra".equals(accountName) && !accountName.contains("valid-admin")) {
+                throw ServiceException.PERM_DENIED("Access Denied. name=" + accountName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Related PR: https://github.com/Zimbra/zm-mailbox/pull/1431

Adding a sample extension to handle a notification called by `notifyExtension`.

**Overview:**
* Handler are registered for the following notifications:
   * notification `com.zimbra.cs.service.account.Auth:validate` called from account Auth
   * notification `com.zimbra.cs.service.admin.Auth:validate` called from account Auth

* The extension throws an exception in the following cases:
    * when account AuthRequest is called and the account name (= email address) contains "invalid" string
    * when admin AuthRequest is called and the account name is not "zimbra" or does not contains "valid-admin" string
    * If the exception is thrown, authentication is failed.