### PR TITLE
Modified unregister call

### DIFF
--- a/src/java/com/zimbra/cs/example/SampleExtension.java
+++ b/src/java/com/zimbra/cs/example/SampleExtension.java
@@ -51,7 +51,7 @@ public class SampleExtension implements ZimbraExtension {
      */
     @Override
     public void destroy() {
-        SampleNotificationHandler.unregister("com.zimbra.cs.service.account.Auth:validate");
-        SampleNotificationHandler.unregister("com.zimbra.cs.service.admin.Auth:validate");
+        ZimbraExtensionNotification.unregister("com.zimbra.cs.service.account.Auth:validate");
+        ZimbraExtensionNotification.unregister("com.zimbra.cs.service.admin.Auth:validate");
     }
 }


### PR DESCRIPTION
**Bug fix:**
A handler is registered using `ZimbraExtensionNotification.register`.
It should be unregistered using `ZimbraExtensionNotification.unregister`.